### PR TITLE
`realm join` also requires `adcli`, `oddjob` and `oddjob-mkhomedir`

### DIFF
--- a/roles/realm_config/defaults/main.yml
+++ b/roles/realm_config/defaults/main.yml
@@ -4,6 +4,8 @@ ad:
   - samba-common-tools
   - sssd-ad
   - krb5-workstation
+  - oddjob-mkhomedir
+  - adcli
 ipa:
   - ipa-client
   - realmd


### PR DESCRIPTION
- `oddjob-mkhomedir` depends on `oddjob`, so no need to explicitly
  depend on that.