### PR TITLE
Better error handling when running `realm join`

### DIFF
--- a/plugins/modules/realm_join.py
+++ b/plugins/modules/realm_join.py
@@ -322,8 +322,16 @@ def run_command(mod_cmd, pexpect, password, module):
         child.expect('Password for ' + module.params["username"] + ":")
         child.sendline(password)
         child.expect(pexpect.EOF)
-        # if child.isalive() == True:
-        #     child.kill(1)
+        # Save any potential error output from the realm process
+        msg = child.before
+        # Close the process so we can get its exit status
+        child.close()
+        rc = child.exitstatus
+
+        if rc != 0:
+            module.fail_json(
+                msg="Unable to join realm",
+                return_value=msg)
     else:
         module.run_command(mod_cmd)
 


### PR DESCRIPTION
This actually came from me missing a single package, and trying to debug why the module failed.  After making it fails with the txt from the `realm join` command, in case of non zero exit code, it noticed that I needed a few packages.  